### PR TITLE
Bugfixes.

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -9,10 +9,9 @@ class GoogleFontLoader extends React.PureComponent {
 
         const families = fonts.reduce((acc, font) => {
             const family = font.font.replace(/ +/g, '+');
+            const weights = (font.weights || []).join(',');
 
-            const weights = font.weights instanceof Array && font.weights.length > 0 ? font.weights.join(',') : '';
-
-            acc.push(`${family}${weights && `:${weights}`}`);
+            acc.push(family + (weights && `:${weights}`));
 
             return acc;
         }, []).join('|');

--- a/src/index.js
+++ b/src/index.js
@@ -9,9 +9,10 @@ class GoogleFontLoader extends React.PureComponent {
 
         const families = fonts.reduce((acc, font) => {
             const family = font.font.replace(/ +/g, '+');
-            const weights = font.weights.join(',');
 
-            acc.push(`${family}:${weights}`);
+            const weights = font.weights instanceof Array && font.weights.length > 0 ? font.weights.join(',') : '';
+
+            acc.push(`${family}${weights && `:${weights}`}`);
 
             return acc;
         }, []).join('|');
@@ -24,7 +25,9 @@ class GoogleFontLoader extends React.PureComponent {
     }
 
     appendLink = () => document.head.appendChild(this.link);
+
     removeLink = () => document.head.removeChild(this.link);
+
     replaceLink = () => {
         this.removeLink();
         this.link = this.createLink();
@@ -47,12 +50,12 @@ class GoogleFontLoader extends React.PureComponent {
     }
 
     render = () => null;
-};
+}
 
 GoogleFontLoader.propTypes = {
     fonts: PropTypes.arrayOf(
         PropTypes.shape({
-            font: PropTypes.string,
+            font: PropTypes.string.isRequired,
             weights: PropTypes.arrayOf(PropTypes.number),
         }),
     ).isRequired,


### PR DESCRIPTION
I've required 'font' attribute to make sure the user passes a font in all their objects passed.
I've also updated the core logic to support cases where weights aren't supplied. - I noticed this happen when I tried to include the Material Icons font (Material+Icons) because it doesn't take any weights.